### PR TITLE
Better error handling + load user images

### DIFF
--- a/githubActivity.js
+++ b/githubActivity.js
@@ -214,7 +214,16 @@
       _ref = this.repos;
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         r = _ref[_i];
-        this.allEvents = this.allEvents.concat(this.data.repoEvents[r]);
+        re = this.data.repoEvents[r]
+        if (typeof(re.message) !== 'undefined') {
+          if (re.message === 'Not Found') {
+            console.warn("GithubActivity: " + r + " is not a valid repo!");
+          } else {
+            console.error(re.message);
+          }
+        } else {
+          this.allEvents = this.allEvents.concat(re);
+        }
       }
       this.allEvents = _.sortBy(this.allEvents, function(e) {
         return e.created_at;

--- a/githubActivity.js
+++ b/githubActivity.js
@@ -97,7 +97,7 @@
   };
   eventHelpers = {
     who: function(ev) {
-      return "<img src='http://www.gravatar.com/avatar/" + ev.actor.gravatar_id + "?s=20'>\n<a href='" + GITHUB + "/" + ev.actor.login + "'>" + ev.actor.login + "</a>";
+      return "<img src='" + ev.actor.avatar_url + "s=20'>\n<a href='" + GITHUB + "/" + ev.actor.login + "'>" + ev.actor.login + "</a>";
     },
     repoUrl: function(ev) {
       return "" + GITHUB + "/" + ev.repo.name;


### PR DESCRIPTION
If an individual repo’s events call return value does not have a message field, it is good, so add to allEvents.

If the message field exists and === ‘Not Found’ then warn and move onto the next repo.  Otherwise, raise the error described in the message field (which is most likely an API request limit).

Currently, the widget completely fails to load if at least one repo is mistyped.  It also gives an unhelpful String error for an API request limit error.
